### PR TITLE
Update geom_range.R to fix issue #306

### DIFF
--- a/R/geom_range.R
+++ b/R/geom_range.R
@@ -51,8 +51,8 @@ geom_range_internal <- function(range, center, ...) {
 StatRange <- ggproto("StatRange", Stat,
                      compute_group = function(self, data, scales, params) {
                          df <- data[!is.na(data[["lower"]]),]
-                         df[["lower"]] <- df[["lower"]] + df[["x"]] - as.numeric(df[["center"]])
-                         df[["upper"]] <- df[["upper"]] + df[["x"]] - as.numeric(df[["center"]])
+                         df[["lower"]] <- -df[["lower"]] + as.numeric(df[["center"]]) + df[["x"]] 
+                         df[["upper"]] <- -df[["upper"]] + as.numeric(df[["center"]]) + df[["x"]] 
 
                          data.frame(x = df[["lower"]],
                                     xend = df[["upper"]],


### PR DESCRIPTION
Change the signs (+ and -) in order to correctly plot the lower and upper values of the ranges in geom_range.
Before this change, the values were "mirrored", leading to incorrect range displays when the heights of the nodes were not exactly at the center of the range. Now, the values are "transposed", which corrects this issue.
This works both with or without adding the revts() function.